### PR TITLE
(refs #3525) bootstrap-modal.jsのapiを使用しないよう修正

### DIFF
--- a/data/patches/opCommunityTopicPlugin.patch
+++ b/data/patches/opCommunityTopicPlugin.patch
@@ -12,7 +12,7 @@ index 16e39af..2c4e439 100644
 +<span class="like-post">いいね！</span>
 +<span class="like-cancel">いいね！を取り消す&nbsp;</span>
 +<span class="like-you">あなたが「いいね！」と言っています。</span><br />
-+<a class="like-list" href="#likeModal" data-toggle="modal"></a>
++<a class="like-list" href="javascript:void(0)" onclick="$('#likeModal').modal('show')"></a>
 +<div class="like-list-member"></div>
 +<span class="like-friend-list"></span>
 +</span>
@@ -58,7 +58,7 @@ index 1c3c31d..c6af9da 100644
 +<span class="like-post">いいね！</span>
 +<span class="like-cancel">いいね！を取り消す&nbsp;</span>
 +<span class="like-you">あなたが「いいね！」と言っています。</span><br />
-+<a class="like-list" href="#likeModal" data-toggle="modal"></a>
++<a class="like-list" href="javascript:void(0)" onclick="$('#likeModal').modal('show')"></a>
 +<div class="like-list-member"></div>
 +<span class="like-friend-list"></span>
 +</span>

--- a/data/patches/opDiaryPlugin.patch
+++ b/data/patches/opDiaryPlugin.patch
@@ -12,7 +12,7 @@ index 258d189..941aad0 100644
 +<span class="like-post">いいね！</span>
 +<span class="like-cancel">いいね！を取り消す&nbsp;</span>
 +<span class="like-you">あなたが「いいね！」と言っています。</span><br />
-+<a class="like-list" href="#likeModal" data-toggle="modal"></a>
++<a class="like-list" href="javascript:void(0)" onclick="$('#likeModal').modal('show')"></a>
 +<div class="like-list-member"></div>
 +<span class="like-friend-list"></span>
 +</span>
@@ -58,7 +58,7 @@ index dc648ca..6560e78 100644
 +<span class="like-post">いいね！</span>
 +<span class="like-cancel">いいね！を取り消す&nbsp;</span>
 +<span class="like-you">あなたが「いいね！」と言っています。</span><br />
-+<a class="like-list" href="#likeModal" data-toggle="modal"></a>
++<a class="like-list" href="javascript:void(0)" onclick="$('#likeModal').modal('show')"></a>
 +<div class="like-list-member"></div>
 +<span class="like-friend-list"></span>
 +</span>

--- a/data/patches/opTimelinePlugin.patch
+++ b/data/patches/opTimelinePlugin.patch
@@ -168,7 +168,7 @@ index f15bb06..6e38246 100644
 +             <span class="like-post">いいね！</span>
 +             <span class="like-cancel">いいね！を取り消す&nbsp;</span>
 +             <span class="like-you">あなたが「いいね！」と言っています。</span><div></div>
-+             <a class="like-list" href="#likeModal" data-toggle="modal"></a>
++             <a class="like-list" href="javascript:void(0)" onclick="$('#likeModal').modal('show')"></a>
 +             <div class="like-list-member"></div>
 +             <span class="like-friend-list"></span>
 +             </span>
@@ -186,7 +186,7 @@ index f15bb06..6e38246 100644
 +            <span class="like-post">いいね！</span>
 +            <span class="like-cancel">いいね！を取り消す&nbsp;</span>
 +            <span class="like-you">あなたが「いいね！」と言っています。</span><div></div>
-+            <a class="like-list" href="#likeModal" data-toggle="modal"></a>
++            <a class="like-list" href="javascript:void(0)" onclick="$('#likeModal').modal('show')"></a>
 +            <div class="like-list-member"></div>
 +            <span class="like-friend-list"></span>
 +            </span>


### PR DESCRIPTION
他のプラグインがbootstrap-modal.jsを利用している場合に，同一ページ内でこのapi(data-toggle="modal")を利用していると，クリックイベントが重複登録される可能性がある。クリックイベントの登録先を明示的にするため，data-toggle="modal"を利用しないように修正する。
